### PR TITLE
feat: follow proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,5 @@ module.exports = async function httpRequestToUrl (request, opts = {}) {
 }
 
 function isProxiedRequest (request) {
-  console.log(request.path)
   return request.path.indexOf('https:') === 0 || request.path.indexOf('http:') === 0
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@ const socketLocation = require('socket-location')
 
 module.exports = async function httpRequestToUrl (request, opts = {}) {
   // default to true
-  opts.followProxies = !!opts.followProxies
+  console.log(opts.followProxies)
+  console.log(!!opts.followProxies)
+  opts.followProxies = opts.followProxies !== false
+  console.log(opts.followProxies)
 
   if (!request.socket) {
     await awaitEvent(request, 'socket')

--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ const socketLocation = require('socket-location')
 
 module.exports = async function httpRequestToUrl (request, opts = {}) {
   // default to true
-  opts.followProxies = Object.prototype.hasOwnProperty.call(opts, 'followProxies')
-    ? opts.followProxies : true
+  opts.followProxies = !!opts.followProxies
 
   if (!request.socket) {
     await awaitEvent(request, 'socket')

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 const awaitEvent = require('await-event')
 const socketLocation = require('socket-location')
 
-module.exports = async function httpRequestToUrl (request) {
+module.exports = async function httpRequestToUrl (request, opts = {}) {
+  // default to true
+  opts.followProxies = opts.hasOwnProperty('followProxies') ? opts.followProxies : true
+
   if (!request.socket) {
     await awaitEvent(request, 'socket')
   }
@@ -10,5 +13,14 @@ module.exports = async function httpRequestToUrl (request) {
   const proto = `http${socket.encrypted ? 's' : ''}:`
   const location = await socketLocation(socket)
 
+  if (isProxiedRequest(request) && opts.followProxies) {
+    return request.path
+  }
+
   return `${proto}//${location}${request.path}`
+}
+
+function isProxiedRequest (request) {
+  console.log(request.path)
+  return request.path.indexOf('https:') === 0 || request.path.indexOf('http:') === 0
 }

--- a/index.js
+++ b/index.js
@@ -3,10 +3,7 @@ const socketLocation = require('socket-location')
 
 module.exports = async function httpRequestToUrl (request, opts = {}) {
   // default to true
-  console.log(opts.followProxies)
-  console.log(!!opts.followProxies)
   opts.followProxies = opts.followProxies !== false
-  console.log(opts.followProxies)
 
   if (!request.socket) {
     await awaitEvent(request, 'socket')

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const socketLocation = require('socket-location')
 
 module.exports = async function httpRequestToUrl (request, opts = {}) {
   // default to true
-  opts.followProxies = opts.hasOwnProperty('followProxies') ? opts.followProxies : true
+  opts.followProxies = Object.prototype.hasOwnProperty.call(opts, 'followProxies')
+    ? opts.followProxies : true
 
   if (!request.socket) {
     await awaitEvent(request, 'socket')
@@ -15,6 +16,10 @@ module.exports = async function httpRequestToUrl (request, opts = {}) {
 
   if (isProxiedRequest(request) && opts.followProxies) {
     return request.path
+  }
+
+  if (isProxiedRequest(request) && !opts.followProxies) {
+    return `${proto}//${location}`
   }
 
   return `${proto}//${location}${request.path}`

--- a/test.js
+++ b/test.js
@@ -29,6 +29,27 @@ tap.test('after connect', async t => {
   t.end()
 })
 
+tap.test('proxy', async t => {
+  const { port } = await makeServer()
+
+  const opts = {
+    host: '127.0.0.1',
+    port,
+    method: 'GET',
+    path: 'http://example.com/foo'
+  }
+  const client = http.request(opts, res => res.resume())
+  client.end()
+
+  const location = await httpRequestToUrl(client)
+  t.equal(location, 'http://example.com/foo')
+
+  const location2 = await httpRequestToUrl(client, {followProxies:true})
+  t.equal(location2, 'http://example.com/foo')
+
+  t.end()
+})
+
 function makeServer () {
   return new Promise(resolve => {
     const server = http.createServer((req, res) => {

--- a/test.js
+++ b/test.js
@@ -44,12 +44,29 @@ tap.test('proxy', async t => {
   const location = await httpRequestToUrl(client)
   t.equal(location, 'http://example.com/foo')
 
-  const location2 = await httpRequestToUrl(client, {followProxies:true})
+  const location2 = await httpRequestToUrl(client, { followProxies: true })
   t.equal(location2, 'http://example.com/foo')
 
   t.end()
 })
 
+tap.test('proxy do not follow', async t => {
+  const { port } = await makeServer()
+
+  const opts = {
+    host: '127.0.0.1',
+    port,
+    method: 'GET',
+    path: 'http://example.com/foo'
+  }
+  const client = http.request(opts, res => res.resume())
+  client.end()
+
+  const location = await httpRequestToUrl(client, { followProxies: false })
+  t.equal(location, `http://127.0.0.1:${port}`)
+
+  t.end()
+})
 function makeServer () {
   return new Promise(resolve => {
     const server = http.createServer((req, res) => {


### PR DESCRIPTION
Fix for #1.  This PR adds @watson's test to the suite, implements a options array for the `httpRequestToUrl` function, and adds new behavior to return `request.path` when the request looks like a proxied request.    Per suggestions from the issue thread,  this options array has a single option, `followProxies`, which defaults to true. 

Additional comments inline.